### PR TITLE
Implementation of runtime scale adjusting through resizing the fullscreen mode

### DIFF
--- a/src/main/java/fri/shapesge/engine/Game.java
+++ b/src/main/java/fri/shapesge/engine/Game.java
@@ -93,4 +93,8 @@ public class Game {
     public GameSoundSystem getGameSoundSystem() {
         return this.gameSoundSystem;
     }
+
+    public void updateFullscreenResolution(int width, int height) {
+        this.gameWindow.resizeFullscreenResolution(width, height);
+    }
 }

--- a/src/main/java/fri/shapesge/engine/Game.java
+++ b/src/main/java/fri/shapesge/engine/Game.java
@@ -94,7 +94,7 @@ public class Game {
         return this.gameSoundSystem;
     }
 
-    public void updateFullscreenResolution(int width, int height) {
-        this.gameWindow.resizeFullscreenResolution(width, height);
+    public void adjustFullscreenScaling(int width, int height) {
+        this.gameWindow.resizeFullscreenScaling(width, height);
     }
 }

--- a/src/main/java/fri/shapesge/engine/GameWindow.java
+++ b/src/main/java/fri/shapesge/engine/GameWindow.java
@@ -2,15 +2,7 @@ package fri.shapesge.engine;
 
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
-import java.awt.AWTEvent;
-import java.awt.Canvas;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Graphics2D;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.awt.GridLayout;
+import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.KeyEvent;
@@ -119,6 +111,16 @@ class GameWindow {
             if (!this.frame.isVisible()) {
                 this.frame.setVisible(true);
             }
+        }
+    }
+
+    public void resizeFullscreenResolution(int width, int height) {
+        if (this.isFullscreen) {
+            Dimension dimension = new Dimension(width, height);
+            DEVICE.getFullScreenWindow().setSize(dimension);
+            this.frame.setSize(dimension);
+            this.gamePanel.setSize(dimension);
+
         }
     }
 

--- a/src/main/java/fri/shapesge/engine/GameWindow.java
+++ b/src/main/java/fri/shapesge/engine/GameWindow.java
@@ -2,7 +2,15 @@ package fri.shapesge.engine;
 
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
-import java.awt.*;
+import java.awt.AWTEvent;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.GridLayout;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.KeyEvent;
@@ -21,8 +29,8 @@ class GameWindow {
     private final GameObjects gameObjects;
     private final GameInputProcessor gameInputProcessor;
     private final GameFPSCounter fpsCounter;
-    private final int width;
-    private final int height;
+    private int width;
+    private int height;
     private final GameEventDispatcher gameEventDispatcher;
     private final Color backgroundColor;
     private final boolean showInfo;
@@ -114,13 +122,19 @@ class GameWindow {
         }
     }
 
-    public void resizeFullscreenResolution(int width, int height) {
+    public void resizeFullscreenScaling(int width, int height) {
         if (this.isFullscreen) {
-            Dimension dimension = new Dimension(width, height);
-            DEVICE.getFullScreenWindow().setSize(dimension);
-            this.frame.setSize(dimension);
-            this.gamePanel.setSize(dimension);
+            DEVICE.setFullScreenWindow(null);
 
+            this.width = width;
+            this.height = height;
+
+            Dimension dimension = new Dimension(width, height);
+            this.frame.setSize(dimension);
+            this.gamePanel.setPreferredSize(dimension);
+
+            DEVICE.setFullScreenWindow(this.frame);
+            this.gamePanel.resized();
         }
     }
 


### PR DESCRIPTION
Pre potreby semestrálnej práce môjho kolegu Jakuba Leška som implementoval metódu pre resizing rozhrania v režime fullscreen, a to za behu programu. V súlade s existujúcou funkcionalitou škálovania v `private void GamePanel#resized()` je tak možné dosiahnuť dynamickú zmenu škálovania vykreslovaných objektov pre potreby napr. rozšírenia herného poľa, a iné. 

Prosím o zváženie implementácie tejto funkcie.

------

For my colleague Jakub Leško’s semester project, I implemented a method for resizing the interface in full-screen mode at runtime. In accordance with the existing functionality of `private void GamePanel#resized()`, this results in a dynamic change in the scaling of rendered objects, for example, to allow expansion of the game field and similar use cases.

Please give careful consideration to the implementation of this feature.

- Adam Vlčko.